### PR TITLE
Updated readme with missing ALSA dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 sudo apt-get install \
     git \
     build-essential \
+    libasound2-dev \
     libx11-dev \
     libxrandr-dev \
     libxcursor-dev \


### PR DESCRIPTION
The current commit doesn't build on my factory PocketCHIP, citing that `pkg-config` can't find `alsa.pc`, and the compilation fails because it can't find `alsa/asoundlib.h`.

I have added it to the list of dependencies in the readme in alphabetical order.
