### PR TITLE
Apt repository support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: all archive
+
+ROOT=archive
+SECTION=main
+ARCHES=armhf
+RELEASES=jessie
+
+
+#all: prep-jessie archive release-jessie
+all: $(addprefix prep-,$(RELEASES)) archive $(addprefix release-,$(RELEASES))
+
+prep-%:
+	echo "prep for $*"
+	test -e apt-release-$*.conf # Bail unless we have a conf for this arch
+	mkdir -p archive/dists/$*/main/binary-$(ARCHES)
+
+archive:
+	mkdir -p $(ROOT)/pool/$(SECTION)
+	cp pocket-home_*.deb $(ROOT)/pool/$(SECTION)
+	rm -f /tmp/packages*.db # Cache causes issues when rebuilding
+	apt-ftparchive generate apt-ftparchive.conf
+
+release-%:
+	apt-ftparchive -c apt-release-$*.conf release archive/dists/$* > archive/dists/$*/Release
+	gpg --yes --output archive/dists/$*/Release.gpg -ba archive/dists/$*/Release

--- a/apt-ftparchive.conf
+++ b/apt-ftparchive.conf
@@ -1,0 +1,19 @@
+Dir {
+	ArchiveDir "./archive";
+	CacheDir "/tmp";
+};
+Default {
+	Packages::Compress ". gzip bzip2";
+	Contents::Compress ". gzip bzip2";
+};
+TreeDefault {
+	Directory "pool/$(SECTION)";
+	Packages "$(DIST)/$(SECTION)/binary-$(ARCH)/Packages";
+	Contents "$(DIST)/Contents-$(ARCH)";
+};
+
+Tree "dists/jessie" {
+	Sections "main";
+	Architectures "armhf";
+}
+

--- a/apt-release-jessie.conf
+++ b/apt-release-jessie.conf
@@ -1,0 +1,6 @@
+APT::FTPArchive::Release::Codename "jessie";
+APT::FTPArchive::Release::Origin "Marshmallow";
+APT::FTPArchive::Release::Components "main";
+APT::FTPArchive::Release::Label "Pocket Home Marshmallow Edition";
+APT::FTPArchive::Release::Architectures "armhf";
+APT::FTPArchive::Release::Suite "stable";


### PR DESCRIPTION
Hi!

I found the ad-hoc system with `./install-pockethome` etc kind of confusing. After all, Debian already has existing infrastructure for distributing packages, checking versions, managing dependencies (like `xinput-calibrator`) and automatically installing updates. Why not use that?

Well, I figured I'd put my money where my mouth is, so here's a Makefile + config to create a Debian archive in Github Pages. You just put any matching debs into the root of the repo (eg, by running `make` in the `master` branch). Then run `make` in the `gh-pages` branch. This generates files in the `archive` subdirectory that you can commit and push to publish. You can see what that looks like [on my fork](https://github.com/sgentle/PocketCHIP-pocket-home/tree/gh-pages/archive).

If you want to test it out, here's how you do it. (Keep in mind that by running these commands you're letting me run arbitrary code on your CHIP so, uh, only do it on a CHIP with nothing important on it.)

1. Add https support to apt

```
sudo apt-get install apt-transport-https
```

2. Add source to `sources.list`

```
echo "deb https://sgentle.github.io/PocketCHIP-pocket-home/archive/ jessie main" | sudo tee /etc/apt/sources.list.d/marshmallow-pocket-chip-home.list
```

3. Add my public key to apt
```
sudo apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 05E4BBFC
```

4. Fix pocket-home being pinned by nextthing
```
echo -e "Package: pocket-home\nPin: version *\nPin-Priority: 1050" | sudo tee /etc/apt/preferences.d/unpin-pocket-home.pref
```

5. Update
```
sudo apt-get update
```

6. Upgrade pocket-home

```
sudo apt-get install pocket-home
```